### PR TITLE
Install games from wudump and Delete after Install

### DIFF
--- a/src/common/fs_defs.h
+++ b/src/common/fs_defs.h
@@ -24,35 +24,15 @@ extern "C" {
 /* max length of file/dir name */
 #define FS_MAX_ENTNAME_SIZE             256
 
+#define SD_INSTALL_PATH                 "fs:/vol/external01/install"
+#define SD_WUDUMP_PATH                  "fs:/vol/external01/wudump"
+
 #define FS_SOURCETYPE_EXTERNAL          0
 #define FS_SOURCETYPE_HFIO              1
 #define FS_SOURCETYPE_HFIO              1
 
-#define FS_MOUNT_SOURCE_SIZE            0x300
 #define FS_CLIENT_SIZE                  0x1700
 #define FS_CMD_BLOCK_SIZE               0xA80
-
-typedef struct
-{
-    uint32_t flag;
-    uint32_t permission;
-    uint32_t owner_id;
-    uint32_t group_id;
-    uint32_t size;
-    uint32_t alloc_size;
-    uint64_t quota_size;
-    uint32_t ent_id;
-    uint64_t ctime;
-    uint64_t mtime;
-    uint8_t attributes[48];
-} __attribute__((packed)) FSStat;
-
-typedef struct
-{
-    FSStat      stat;
-    char        name[FS_MAX_ENTNAME_SIZE];
-} FSDirEntry;
-
 
 #ifdef __cplusplus
 }

--- a/src/fs/CFolderList.cpp
+++ b/src/fs/CFolderList.cpp
@@ -28,6 +28,7 @@
 #include "CFolderList.hpp"
 #include "DirList.h"
 #include "CFile.hpp"
+#include "common/fs_defs.h"
 #include <coreinit/internal.h>
 
 void CFolderList::AddFolder()
@@ -178,13 +179,13 @@ int CFolderList::Get()
 {
 	Reset();
 	
-	ScanPath("fs:/vol/external01/install", false);
-	ScanPath("fs:/vol/external01/wudump", true);
+	ScanPath(SD_INSTALL_PATH, false);
+	ScanPath(SD_WUDUMP_PATH, true);
 	
 	if(Folders.size() == 0)
 	{
 		DirList dir;
-		dir.LoadPath("fs:/vol/external01/install", ".tik", DirList::Files);
+		dir.LoadPath(SD_INSTALL_PATH, ".tik", DirList::Files);
 		
 		int cnt = dir.GetFilecount();
 		if(cnt > 0)
@@ -192,7 +193,7 @@ int CFolderList::Get()
 			AddFolder();
 			FolderStruct * folder = Folders.back();
 			folder->name = "install";
-			folder->path = "fs:/vol/external01/install";
+			folder->path = SD_INSTALL_PATH;
 			folder->selected = false;
 			folder->sequence = 0;
 		}

--- a/src/fs/CFolderList.cpp
+++ b/src/fs/CFolderList.cpp
@@ -31,11 +31,11 @@
 #include "common/fs_defs.h"
 #include <coreinit/internal.h>
 
-void CFolderList::AddFolder()
+void CFolderList::AddFolder(const std::string& name, const std::string& path)
 {
 	FolderStruct * newFolder = new FolderStruct;
-	newFolder->name = "";
-	newFolder->path = "";
+	newFolder->name = name;
+	newFolder->path = path;
 	newFolder->selected = false;
 	newFolder->sequence = 0;
 	
@@ -190,12 +190,7 @@ int CFolderList::Get()
 		int cnt = dir.GetFilecount();
 		if(cnt > 0)
 		{
-			AddFolder();
-			FolderStruct * folder = Folders.back();
-			folder->name = "install";
-			folder->path = SD_INSTALL_PATH;
-			folder->selected = false;
-			folder->sequence = 0;
+			AddFolder("install", SD_INSTALL_PATH);
 		}
 	}
 	
@@ -212,25 +207,16 @@ void CFolderList::ScanPath(const std::string & rootPath, bool recursive, const s
 		std::string path = dir.GetFilepath(i);
 		std::string titleTikPath = path + "/title.tik";
 		
-		CFile * file = new CFile(titleTikPath, CFile::ReadOnly);
+		CFile file(titleTikPath, CFile::ReadOnly);
 		
-		if(file->isOpen())
+		if(file.isOpen())
 		{
-			AddFolder();
-			FolderStruct * folder = Folders.back();
-			if (prefix.empty())
-				folder->name = dir.GetFilename(i);
-			else
-				folder->name = prefix + ": " + dir.GetFilename(i);
-			folder->path = dir.GetFilepath(i);
-			folder->selected = false;
-			folder->sequence = 0;
+			std::string name = prefix.empty() ? dir.GetFilename(i) : prefix + ": " + dir.GetFilename(i);
+			AddFolder(name, dir.GetFilepath(i));
 		}
 		else if(recursive)
 		{
 			ScanPath(path, false, dir.GetFilename(i));
 		}
-		
-		delete file;
 	}
 }

--- a/src/fs/CFolderList.cpp
+++ b/src/fs/CFolderList.cpp
@@ -178,48 +178,58 @@ int CFolderList::Get()
 {
 	Reset();
 	
-	DirList dir("fs:/vol/external01/install", NULL, DirList::Dirs);
+	ScanPath("fs:/vol/external01/install", false);
+	ScanPath("fs:/vol/external01/wudump", true);
 	
-	int cnt = dir.GetFilecount();
-	if(cnt > 0)
+	if(Folders.size() == 0)
 	{
-		int j = 0;
-		
-		for(int i = 0; i < cnt; i++)
-		{
-			std::string path = dir.GetFilepath(i);
-			path += "/title.tik";
-			
-			CFile * file = new CFile(path, CFile::ReadOnly);
-			
-			if(file->isOpen())
-			{
-				AddFolder();
-				Folders.at(j)->name = dir.GetFilename(i);
-				Folders.at(j)->path = dir.GetFilepath(i);
-				Folders.at(j)->selected = false;
-				Folders.at(j)->sequence = 0;
-				
-				j++;
-			}
-			
-			delete file;
-		}
-	}
-	else
-	{
+		DirList dir;
 		dir.LoadPath("fs:/vol/external01/install", ".tik", DirList::Files);
 		
-		cnt = dir.GetFilecount();
+		int cnt = dir.GetFilecount();
 		if(cnt > 0)
 		{
 			AddFolder();
-			Folders.at(0)->name = "install";
-			Folders.at(0)->path = "fs:/vol/external01/install";
-			Folders.at(0)->selected = false;
-			Folders.at(0)->sequence = 0;
+			FolderStruct * folder = Folders.back();
+			folder->name = "install";
+			folder->path = "fs:/vol/external01/install";
+			folder->selected = false;
+			folder->sequence = 0;
 		}
 	}
 	
 	return Folders.size();
+}
+
+void CFolderList::ScanPath(const std::string & rootPath, bool recursive, const std::string & prefix)
+{
+	DirList dir(rootPath, NULL, DirList::Dirs);
+	
+	int cnt = dir.GetFilecount();
+	for(int i = 0; i < cnt; i++)
+	{
+		std::string path = dir.GetFilepath(i);
+		std::string titleTikPath = path + "/title.tik";
+		
+		CFile * file = new CFile(titleTikPath, CFile::ReadOnly);
+		
+		if(file->isOpen())
+		{
+			AddFolder();
+			FolderStruct * folder = Folders.back();
+			if (prefix.empty())
+				folder->name = dir.GetFilename(i);
+			else
+				folder->name = prefix + ": " + dir.GetFilename(i);
+			folder->path = dir.GetFilepath(i);
+			folder->selected = false;
+			folder->sequence = 0;
+		}
+		else if(recursive)
+		{
+			ScanPath(path, false, dir.GetFilename(i));
+		}
+		
+		delete file;
+	}
 }

--- a/src/fs/CFolderList.hpp
+++ b/src/fs/CFolderList.hpp
@@ -40,7 +40,7 @@ class CFolderList
 		
 		int Get();
 		void Reset();
-		void AddFolder();
+		void AddFolder(const std::string& name, const std::string& path);
 		int GetCount() { return Folders.size(); };
 		int GetSelectedCount();
 		std::string GetName(int ind);

--- a/src/fs/CFolderList.hpp
+++ b/src/fs/CFolderList.hpp
@@ -55,6 +55,7 @@ class CFolderList
 		void Click(int ind);
 		
 	protected:
+		void ScanPath(const std::string & rootPath, bool recursive, const std::string & prefix = "");
 		void AddSequence(int index);
 		void RemoveSequence(int index);
 		

--- a/src/fs/fs_utils.c
+++ b/src/fs/fs_utils.c
@@ -230,3 +230,53 @@ int RemoveDirectory(const char *path)
 
 	return r;
 }
+
+int IsDirectoryEmpty(const char *path)
+{
+	DIR *d = opendir(path);
+	if (!d) return 0;
+
+	struct dirent *p;
+	int empty = 1;
+	while ((p = readdir(d)))
+	{
+		if (!strcmp(p->d_name, ".") || !strcmp(p->d_name, ".."))
+			continue;
+		empty = 0;
+		break;
+	}
+	closedir(d);
+	return empty;
+}
+
+void RemoveDirectoryAndEmptyParents(const char *path, const char *stopAt)
+{
+	if (RemoveDirectory(path) != 0)
+		return;
+
+	char parent[512];
+	strncpy(parent, path, sizeof(parent));
+	parent[sizeof(parent)-1] = '\0';
+
+	while (1)
+	{
+		char *slash = strrchr(parent, '/');
+		if (!slash) break;
+		*slash = '\0';
+
+		// Stop if we reached the limit or a root mount point
+		if ((stopAt && strcmp(parent, stopAt) == 0) ||
+			strlen(parent) < 20)
+			break;
+
+		if (IsDirectoryEmpty(parent))
+		{
+			if (rmdir(parent) != 0)
+				break;
+		}
+		else
+		{
+			break;
+		}
+	}
+}

--- a/src/fs/fs_utils.c
+++ b/src/fs/fs_utils.c
@@ -4,6 +4,8 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <dirent.h>
+#include <sys/stat.h>
 #include <coreinit/filesystem.h>
 
 #define FS_MAX_MOUNTPATH_SIZE           128
@@ -180,4 +182,51 @@ int CreateSubfolder(const char * fullpath)
 	}
 
 	return 1;
+}
+
+int RemoveDirectory(const char *path)
+{
+	DIR *d = opendir(path);
+	size_t path_len = strlen(path);
+	int r = -1;
+
+	if (d)
+	{
+		struct dirent *p;
+		r = 0;
+		while (!r && (p = readdir(d)))
+		{
+			int r2 = -1;
+			char *buf;
+			size_t len;
+
+			/* Skip the names "." and ".." as we don't want to recurse on them. */
+			if (!strcmp(p->d_name, ".") || !strcmp(p->d_name, ".."))
+				continue;
+
+			len = path_len + strlen(p->d_name) + 2;
+			buf = (char *) malloc(len);
+
+			if (buf)
+			{
+				struct stat statbuf;
+				snprintf(buf, len, "%s/%s", path, p->d_name);
+				if (!stat(buf, &statbuf))
+				{
+					if (S_ISDIR(statbuf.st_mode))
+						r2 = RemoveDirectory(buf);
+					else
+						r2 = unlink(buf);
+				}
+				free(buf);
+			}
+			r = r2;
+		}
+		closedir(d);
+	}
+
+	if (!r)
+		r = rmdir(path);
+
+	return r;
 }

--- a/src/fs/fs_utils.c
+++ b/src/fs/fs_utils.c
@@ -6,6 +6,7 @@
 #include <fcntl.h>
 #include <dirent.h>
 #include <sys/stat.h>
+#include <errno.h>
 #include <coreinit/filesystem.h>
 
 #define FS_MAX_MOUNTPATH_SIZE           128
@@ -194,6 +195,7 @@ int RemoveDirectory(const char *path)
 	{
 		struct dirent *p;
 		r = 0;
+		errno = 0;
 		while (!r && (p = readdir(d)))
 		{
 			int r2 = -1;
@@ -214,14 +216,20 @@ int RemoveDirectory(const char *path)
 				if (!stat(buf, &statbuf))
 				{
 					if (S_ISDIR(statbuf.st_mode))
-						r2 = RemoveDirectory(buf);
+						// We don't expect subdirectories in install folders. Let it fail if not empty.
+						r2 = rmdir(buf);
 					else
 						r2 = unlink(buf);
 				}
 				free(buf);
 			}
 			r = r2;
+			errno = 0;
 		}
+
+		if (errno != 0)
+			r = -1;
+
 		closedir(d);
 	}
 
@@ -229,24 +237,6 @@ int RemoveDirectory(const char *path)
 		r = rmdir(path);
 
 	return r;
-}
-
-int IsDirectoryEmpty(const char *path)
-{
-	DIR *d = opendir(path);
-	if (!d) return 0;
-
-	struct dirent *p;
-	int empty = 1;
-	while ((p = readdir(d)))
-	{
-		if (!strcmp(p->d_name, ".") || !strcmp(p->d_name, ".."))
-			continue;
-		empty = 0;
-		break;
-	}
-	closedir(d);
-	return empty;
 }
 
 void RemoveDirectoryAndEmptyParents(const char *path, const char *stopAt)
@@ -269,14 +259,8 @@ void RemoveDirectoryAndEmptyParents(const char *path, const char *stopAt)
 			strlen(parent) < 20)
 			break;
 
-		if (IsDirectoryEmpty(parent))
-		{
-			if (rmdir(parent) != 0)
-				break;
-		}
-		else
-		{
+		// rmdir will intentionally fail and return non-zero if the directory is not empty
+		if (rmdir(parent) != 0)
 			break;
-		}
 	}
 }

--- a/src/fs/fs_utils.h
+++ b/src/fs/fs_utils.h
@@ -16,6 +16,8 @@ int LoadFileToMem(const char *filepath, u8 **inbuffer, u32 *size);
 int CreateSubfolder(const char * fullpath);
 int CheckFile(const char * filepath);
 int RemoveDirectory(const char *path);
+int IsDirectoryEmpty(const char *path);
+void RemoveDirectoryAndEmptyParents(const char *path, const char *stopAt);
 
 #ifdef __cplusplus
 }

--- a/src/fs/fs_utils.h
+++ b/src/fs/fs_utils.h
@@ -15,6 +15,7 @@ int LoadFileToMem(const char *filepath, u8 **inbuffer, u32 *size);
 //! todo: C++ class
 int CreateSubfolder(const char * fullpath);
 int CheckFile(const char * filepath);
+int RemoveDirectory(const char *path);
 
 #ifdef __cplusplus
 }

--- a/src/fs/fs_utils.h
+++ b/src/fs/fs_utils.h
@@ -16,7 +16,6 @@ int LoadFileToMem(const char *filepath, u8 **inbuffer, u32 *size);
 int CreateSubfolder(const char * fullpath);
 int CheckFile(const char * filepath);
 int RemoveDirectory(const char *path);
-int IsDirectoryEmpty(const char *path);
 void RemoveDirectoryAndEmptyParents(const char *path, const char *stopAt);
 
 #ifdef __cplusplus

--- a/src/menu/BrowserWindow.cpp
+++ b/src/menu/BrowserWindow.cpp
@@ -34,9 +34,11 @@ BrowserWindow::BrowserWindow(int w, int h, CFolderList * list)
     , minusImageData(Resources::GetImageData("minus.png"))
 	, plusImg(plusImageData)
 	, minusImg(minusImageData)
-	, plusTxt("Select All", 42, glm::vec4(0.9f, 0.9f, 0.9f, 1.0f))
-	, minusTxt("Unselect All", 42, glm::vec4(0.9f, 0.9f, 0.9f, 1.0f))
+	, validImageData(Resources::GetImageData("validIcon.png"))
+	, validImg(validImageData)
+	, plusTxt("Select All", 42, glm::vec4(0.9f, 0.9f, 0.9f, 1.0f))	, minusTxt("Unselect All", 42, glm::vec4(0.9f, 0.9f, 0.9f, 1.0f))
 	, installTxt("Install", 42, glm::vec4(0.9f, 0.9f, 0.9f, 1.0f))
+	, deleteTxt("Del. after install", 32, glm::vec4(0.9f, 0.9f, 0.9f, 1.0f))
     , touchTrigger(GuiTrigger::CHANNEL_1, GuiTrigger::VPAD_TOUCH)
     , buttonATrigger(GuiTrigger::CHANNEL_ALL, GuiTrigger::BUTTON_A, true)
     , buttonUpTrigger(GuiTrigger::CHANNEL_ALL, GuiTrigger::BUTTON_UP | GuiTrigger::STICK_L_UP, true)
@@ -50,6 +52,7 @@ BrowserWindow::BrowserWindow(int w, int h, CFolderList * list)
 	, plusButton(selectImg.getWidth(), selectImg.getHeight())
 	, minusButton(selectImg.getWidth(), selectImg.getHeight())
 	, installButton(selectImg.getWidth(), selectImg.getHeight())
+	, deleteButton(selectImg.getWidth(), selectImg.getHeight())
 {
 	folderList = list;
 	pageIndex = 0;
@@ -118,8 +121,8 @@ BrowserWindow::BrowserWindow(int w, int h, CFolderList * list)
     plusButton.setLabel(&plusTxt);
     plusButton.setImage(&selectImg);
 	plusButton.setIcon(&plusImg);
-    plusButton.setAlignment(ALIGN_TOP | ALIGN_RIGHT);
-    plusButton.setPosition(240, -135);
+    plusButton.setAlignment(ALIGN_MIDDLE | ALIGN_RIGHT);
+    plusButton.setPosition(240, 220);
     plusButton.clicked.connect(this, &BrowserWindow::OnPlusButtonClick);
     plusButton.setTrigger(&plusTrigger);
     plusButton.setTrigger(&touchTrigger);
@@ -137,8 +140,8 @@ BrowserWindow::BrowserWindow(int w, int h, CFolderList * list)
     minusButton.setLabel(&minusTxt);
     minusButton.setImage(&unselectImg);
 	minusButton.setIcon(&minusImg);
-    minusButton.setAlignment(ALIGN_TOP | ALIGN_RIGHT);
-    minusButton.setPosition(240, -(selectImg.getWidth()+20) - 135);
+    minusButton.setAlignment(ALIGN_MIDDLE | ALIGN_RIGHT);
+    minusButton.setPosition(240, 66);
     minusButton.clicked.connect(this, &BrowserWindow::OnMinusButtonClick);
     minusButton.setTrigger(&minusTrigger);
     minusButton.setTrigger(&touchTrigger);
@@ -153,8 +156,8 @@ BrowserWindow::BrowserWindow(int w, int h, CFolderList * list)
 	installTxt.setMaxWidth(unselectImg.getWidth()-5, GuiText::WRAP);
     installButton.setLabel(&installTxt);
     installButton.setImage(&installImg);
-	installButton.setAlignment(ALIGN_TOP | ALIGN_RIGHT);
-    installButton.setPosition(240, -(selectImg.getWidth()+20)*2 - 135);
+	installButton.setAlignment(ALIGN_MIDDLE | ALIGN_RIGHT);
+    installButton.setPosition(240, -90);
     installButton.clicked.connect(this, &BrowserWindow::OnInstallButtonClick);
     installButton.setTrigger(&touchTrigger);
     installButton.setSoundClick(buttonClickSound);
@@ -164,6 +167,24 @@ BrowserWindow::BrowserWindow(int w, int h, CFolderList * list)
 	installButton.setImageSelectOver(installButtonSelectedImage);
     this->append(&installButton);
 	rightSideButtons.push_back(&installButton);
+
+	validImg.setAlignment(ALIGN_BOTTOM | ALIGN_RIGHT);
+	validImg.setPosition(-10, 10);
+	validImg.setScale(0.6f);
+	deleteTxt.setMaxWidth(unselectImg.getWidth()-5, GuiText::WRAP);
+    deleteButton.setLabel(&deleteTxt);
+    deleteButton.setImage(&unselectImg);
+	deleteButton.setAlignment(ALIGN_MIDDLE | ALIGN_RIGHT);
+    deleteButton.setPosition(240, -256);
+    deleteButton.clicked.connect(this, &BrowserWindow::OnDeleteButtonClick);
+    deleteButton.setTrigger(&touchTrigger);
+    deleteButton.setSoundClick(buttonClickSound);
+    deleteButton.setEffectGrow();
+	deleteButton.setSelectable(true);
+	deleteButtonSelectedImage = new GuiImage(selectSelectedImageData);
+	deleteButton.setImageSelectOver(deleteButtonSelectedImage);
+    this->append(&deleteButton);
+	rightSideButtons.push_back(&deleteButton);
 }
 
 BrowserWindow::~BrowserWindow()
@@ -183,6 +204,8 @@ BrowserWindow::~BrowserWindow()
 	delete plusButtonSelectedImage;
 	delete minusButtonSelectedImage;
 	delete installButtonSelectedImage;
+	delete deleteButtonSelectedImage;
+	Resources::RemoveImageData(validImageData);
 
     Resources::RemoveImageData(buttonImageData);
     Resources::RemoveImageData(buttonCheckedImageData);
@@ -209,7 +232,7 @@ int BrowserWindow::SearchSelectedButton()
 int BrowserWindow::SearchSelectedRightSideButton()
 {
 	int index = -1;
-	for(int i = 0; i < 3 && index < 0; i++)
+	for(int i = 0; i < 4 && index < 0; i++)
 	{
 		if(rightSideButtons[i]->getState() == STATE_SELECTED)
 			index = i;
@@ -312,7 +335,7 @@ void BrowserWindow::OnDPADClick(GuiButton *button, const GuiController *controll
 			index--;
 			rightSideButtons[index]->setState(STATE_SELECTED);
 		}
-		else if(trigger == &buttonDownTrigger && index < 2)
+		else if(trigger == &buttonDownTrigger && index < 3)
 		{
 			if(index >= 0)
 				rightSideButtons[index]->clearState(STATE_SELECTED);
@@ -385,6 +408,15 @@ void BrowserWindow::OnMinusButtonClick(GuiButton *button, const GuiController *c
 void BrowserWindow::OnInstallButtonClick(GuiButton *button, const GuiController *controller, GuiTrigger *trigger)
 {
 	installButtonClicked(this);
+}
+
+void BrowserWindow::OnDeleteButtonClick(GuiButton *button, const GuiController *controller, GuiTrigger *trigger)
+{
+	deleteAfterInstall = !deleteAfterInstall;
+	if(deleteAfterInstall)
+		button->setIcon(&validImg);
+	else
+		button->setIcon(NULL);
 }
 
 void BrowserWindow::OnScrollbarListChange(int selItem, int selIndex)

--- a/src/menu/BrowserWindow.cpp
+++ b/src/menu/BrowserWindow.cpp
@@ -121,8 +121,8 @@ BrowserWindow::BrowserWindow(int w, int h, CFolderList * list)
     plusButton.setLabel(&plusTxt);
     plusButton.setImage(&selectImg);
 	plusButton.setIcon(&plusImg);
-    plusButton.setAlignment(ALIGN_MIDDLE | ALIGN_RIGHT);
-    plusButton.setPosition(240, 220);
+    plusButton.setAlignment(ALIGN_TOP | ALIGN_RIGHT);
+    plusButton.setPosition(240, -68);
     plusButton.clicked.connect(this, &BrowserWindow::OnPlusButtonClick);
     plusButton.setTrigger(&plusTrigger);
     plusButton.setTrigger(&touchTrigger);
@@ -140,8 +140,8 @@ BrowserWindow::BrowserWindow(int w, int h, CFolderList * list)
     minusButton.setLabel(&minusTxt);
     minusButton.setImage(&unselectImg);
 	minusButton.setIcon(&minusImg);
-    minusButton.setAlignment(ALIGN_MIDDLE | ALIGN_RIGHT);
-    minusButton.setPosition(240, 66);
+    minusButton.setAlignment(ALIGN_TOP | ALIGN_RIGHT);
+    minusButton.setPosition(240, -232);
     minusButton.clicked.connect(this, &BrowserWindow::OnMinusButtonClick);
     minusButton.setTrigger(&minusTrigger);
     minusButton.setTrigger(&touchTrigger);
@@ -156,8 +156,8 @@ BrowserWindow::BrowserWindow(int w, int h, CFolderList * list)
 	installTxt.setMaxWidth(unselectImg.getWidth()-5, GuiText::WRAP);
     installButton.setLabel(&installTxt);
     installButton.setImage(&installImg);
-	installButton.setAlignment(ALIGN_MIDDLE | ALIGN_RIGHT);
-    installButton.setPosition(240, -90);
+	installButton.setAlignment(ALIGN_TOP | ALIGN_RIGHT);
+	installButton.setPosition(240, -396);
     installButton.clicked.connect(this, &BrowserWindow::OnInstallButtonClick);
     installButton.setTrigger(&touchTrigger);
     installButton.setSoundClick(buttonClickSound);
@@ -174,8 +174,8 @@ BrowserWindow::BrowserWindow(int w, int h, CFolderList * list)
 	deleteTxt.setMaxWidth(unselectImg.getWidth()-5, GuiText::WRAP);
     deleteButton.setLabel(&deleteTxt);
     deleteButton.setImage(&unselectImg);
-	deleteButton.setAlignment(ALIGN_MIDDLE | ALIGN_RIGHT);
-    deleteButton.setPosition(240, -256);
+	deleteButton.setAlignment(ALIGN_TOP | ALIGN_RIGHT);
+    deleteButton.setPosition(240, -560);
     deleteButton.clicked.connect(this, &BrowserWindow::OnDeleteButtonClick);
     deleteButton.setTrigger(&touchTrigger);
     deleteButton.setSoundClick(buttonClickSound);

--- a/src/menu/BrowserWindow.cpp
+++ b/src/menu/BrowserWindow.cpp
@@ -34,6 +34,7 @@ BrowserWindow::BrowserWindow(int w, int h, CFolderList * list)
     , minusImageData(Resources::GetImageData("minus.png"))
 	, plusImg(plusImageData)
 	, minusImg(minusImageData)
+	, deleteImg(selectImageData)
 	, validImageData(Resources::GetImageData("validIcon.png"))
 	, validImg(validImageData)
 	, plusTxt("Select All", 42, glm::vec4(0.9f, 0.9f, 0.9f, 1.0f))	, minusTxt("Unselect All", 42, glm::vec4(0.9f, 0.9f, 0.9f, 1.0f))
@@ -153,7 +154,7 @@ BrowserWindow::BrowserWindow(int w, int h, CFolderList * list)
     this->append(&minusButton);
 	rightSideButtons.push_back(&minusButton);
 	
-	installTxt.setMaxWidth(unselectImg.getWidth()-5, GuiText::WRAP);
+	installTxt.setMaxWidth(installImg.getWidth()-5, GuiText::WRAP);
     installButton.setLabel(&installTxt);
     installButton.setImage(&installImg);
 	installButton.setAlignment(ALIGN_TOP | ALIGN_RIGHT);
@@ -171,9 +172,9 @@ BrowserWindow::BrowserWindow(int w, int h, CFolderList * list)
 	validImg.setAlignment(ALIGN_BOTTOM | ALIGN_RIGHT);
 	validImg.setPosition(-10, 10);
 	validImg.setScale(0.6f);
-	deleteTxt.setMaxWidth(unselectImg.getWidth()-5, GuiText::WRAP);
+	deleteTxt.setMaxWidth(deleteImg.getWidth()-5, GuiText::WRAP);
     deleteButton.setLabel(&deleteTxt);
-    deleteButton.setImage(&unselectImg);
+    deleteButton.setImage(&deleteImg);
 	deleteButton.setAlignment(ALIGN_TOP | ALIGN_RIGHT);
     deleteButton.setPosition(240, -560);
     deleteButton.clicked.connect(this, &BrowserWindow::OnDeleteButtonClick);

--- a/src/menu/BrowserWindow.h
+++ b/src/menu/BrowserWindow.h
@@ -39,6 +39,7 @@ private:
 	void OnPlusButtonClick(GuiButton *button, const GuiController *controller, GuiTrigger *trigger);
 	void OnMinusButtonClick(GuiButton *button, const GuiController *controller, GuiTrigger *trigger);
 	void OnInstallButtonClick(GuiButton *button, const GuiController *controller, GuiTrigger *trigger);
+	void OnDeleteButtonClick(GuiButton *button, const GuiController *controller, GuiTrigger *trigger);
 	
 	void OnScrollbarListChange(int selectItem, int pageIndex);
 	
@@ -64,6 +65,7 @@ private:
 	GuiText plusTxt;
 	GuiText minusTxt;
 	GuiText installTxt;
+	GuiText deleteTxt;
     
 	GuiTrigger touchTrigger;
     GuiTrigger buttonATrigger;
@@ -82,16 +84,22 @@ private:
 	GuiButton plusButton;
 	GuiButton minusButton;
 	GuiButton installButton;
+	GuiButton deleteButton;
 	
     GuiImage* plusButtonSelectedImage;
     GuiImage* minusButtonSelectedImage;
     GuiImage* installButtonSelectedImage;
+    GuiImage* deleteButtonSelectedImage;
+
+    GuiImageData *validImageData;
+    GuiImage validImg;
 
     int pageIndex;
 	int selectedItem;
 	int buttonCount;
 	
     bool rightSide = false;
+	bool deleteAfterInstall = false;
     std::vector<GuiButton*> rightSideButtons;
 
     typedef struct
@@ -107,6 +115,9 @@ private:
     std::vector<FolderButton> folderButtons;
 	
 	CFolderList * folderList;
+
+public:
+	bool DeleteAfterInstallEnabled() { return deleteAfterInstall; }
 };
 
 #endif //_BROSERWINDOW_H_

--- a/src/menu/BrowserWindow.h
+++ b/src/menu/BrowserWindow.h
@@ -62,6 +62,7 @@ private:
     GuiImageData *minusImageData;
     GuiImage plusImg;
     GuiImage minusImg;
+    GuiImage deleteImg;
 	
 	GuiText plusTxt;
 	GuiText minusTxt;

--- a/src/menu/BrowserWindow.h
+++ b/src/menu/BrowserWindow.h
@@ -26,6 +26,7 @@ class BrowserWindow : public GuiFrame, public sigslot::has_slots<>
 public:
     BrowserWindow(int w, int h, CFolderList * folderList);
     virtual ~BrowserWindow();
+	bool DeleteAfterInstallEnabled() { return deleteAfterInstall; }
 	
 	sigslot::signal1<GuiElement *> installButtonClicked;
 	
@@ -116,8 +117,6 @@ private:
 	
 	CFolderList * folderList;
 
-public:
-	bool DeleteAfterInstallEnabled() { return deleteAfterInstall; }
 };
 
 #endif //_BROSERWINDOW_H_

--- a/src/menu/InstallWindow.cpp
+++ b/src/menu/InstallWindow.cpp
@@ -19,6 +19,7 @@
 #include "InstallWindow.h"
 #include "utils/StringTools.h"
 #include "common/common.h"
+#include "common/fs_defs.h"
 #include "system/power.h"
 #include "fs/fs_utils.h"
 #include <coreinit/mcp.h>
@@ -340,7 +341,14 @@ void InstallWindow::InstallProcess(int pos, int total)
 	{
 		if(deleteAfterInstall)
 		{
-			RemoveDirectory(folderList->GetPath(index).c_str());
+			std::string path = folderList->GetPath(index);
+			const char * stopAt = NULL;
+			if (path.find(SD_INSTALL_PATH) == 0)
+				stopAt = SD_INSTALL_PATH;
+			else if (path.find(SD_WUDUMP_PATH) == 0)
+				stopAt = SD_WUDUMP_PATH;
+
+			RemoveDirectoryAndEmptyParents(path.c_str(), stopAt);
 		}
 
 		if(pos == total)

--- a/src/menu/InstallWindow.cpp
+++ b/src/menu/InstallWindow.cpp
@@ -20,6 +20,7 @@
 #include "utils/StringTools.h"
 #include "common/common.h"
 #include "system/power.h"
+#include "fs/fs_utils.h"
 #include <coreinit/mcp.h>
 #include <coreinit/memory.h>
 #include <coreinit/ios.h>
@@ -39,10 +40,11 @@ static void* IosInstallCallback(IOSError errorCode, void * priv_data)
 	return 0;
 }
 
-InstallWindow::InstallWindow(CFolderList * list)
+InstallWindow::InstallWindow(CFolderList * list, bool deleteAfterInstall)
 	: GuiFrame(0, 0)
 	, CThread(CThread::eAttributeAffCore0 | CThread::eAttributePinnedAff)
 	, folderList(list)
+	, deleteAfterInstall(deleteAfterInstall)
 {   
 	mainWindow = Application::instance()->getMainWindow();
 	
@@ -336,6 +338,11 @@ void InstallWindow::InstallProcess(int pos, int total)
 	
 	if(result >= 0)
 	{
+		if(deleteAfterInstall)
+		{
+			RemoveDirectory(folderList->GetPath(index).c_str());
+		}
+
 		if(pos == total)
 		{
 			messageBox->reload("Successfully installed", gameName, "", MessageBox::BT_OK, MessageBox::IT_ICONTRUE);

--- a/src/menu/InstallWindow.h
+++ b/src/menu/InstallWindow.h
@@ -10,7 +10,7 @@ class MainWindow;
 class InstallWindow : public GuiFrame, public CThread, public sigslot::has_slots<>
 {
 public:
-	InstallWindow(CFolderList * list);
+	InstallWindow(CFolderList * list, bool deleteAfterInstall = false);
 	~InstallWindow();
 	
 	void startInstalling()
@@ -43,6 +43,7 @@ private:
 	
 	int folderCount;
 	bool canceled;
+	bool deleteAfterInstall;
 	int target;
 	
 	enum

--- a/src/menu/MainWindow.cpp
+++ b/src/menu/MainWindow.cpp
@@ -263,7 +263,7 @@ void MainWindow::OnInstallButtonClicked(GuiElement *element)
 	browserWindow->setState(GuiElement::STATE_DISABLED);
 	browserWindow->effectFinished.connect(this, &MainWindow::OnBrowserCloseEffectFinish);
 	
-	installWindow = new InstallWindow(folderList);
+	installWindow = new InstallWindow(folderList, browserWindow->DeleteAfterInstallEnabled());
 	installWindow->installWindowClosed.connect(this, &MainWindow::OnInstallWindowClosed);
 }
 
@@ -275,6 +275,8 @@ void MainWindow::OnBrowserCloseEffectFinish(GuiElement *element)
 }
 void MainWindow::OnInstallWindowClosed(GuiElement *element)
 {
+	if(folderList)
+		folderList->Get();
 	SetBrowserWindow();
 	currentDrcFrame->bringToFront(&headerFrame);
 }


### PR DESCRIPTION
- Also checks the `wudump` directory on the SD recursively for installable content in addition to `/install`, so games dumped with wudd can be installed directly without moving them first
- add an option to delete WUPs after the install